### PR TITLE
Create filezilla.sh

### DIFF
--- a/fragments/labels/cyberduck.sh
+++ b/fragments/labels/cyberduck.sh
@@ -1,0 +1,11 @@
+cyberduck)
+      appTitle="Cyberduck"
+      appProcesses+=("Cyberduck")
+      appFiles+=("/Applications/Cyberduck.app")
+      appFiles+=("/Users/$loggedInUser/Library/Preferences/ch.sudo.cyberduck.plist")
+      appFiles+=("/Users/$loggedInUser/Library/Application Support/Cyberduck")
+      appFiles+=("/Users/$loggedInUser/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck")
+      appFiles+=("/Users/$loggedInUser/Library/Logs/Cyberduck")
+      appFiles+=("/Users/$loggedInUser/Library/HTTPStorages/ch.sudo.cyberduck")
+      appFiles+=("/Users/$loggedInUser/Library/Saved Application State/ch.sudo.cyberduck.savedState")
+      ;;

--- a/fragments/labels/filezilla.sh
+++ b/fragments/labels/filezilla.sh
@@ -1,0 +1,7 @@
+filezilla)
+      appTitle="FileZilla"
+      appProcesses+=("filezilla")
+      appFiles+=("/Applications/FileZilla.app")
+      appFiles+=("/Users/$loggedInUser/Library/Preferences/org.filezilla-project.filezilla.plist")
+      appFiles+=("/Users/$loggedInUser/Library/Saved Application State/org.filezilla-project.filezilla.savedState")
+;;


### PR DESCRIPTION
2023-01-13 16:13:07 Uninstaller started - version 2022-12-27 (build: Tue Dec 27 10:22:23 CET 2022) 2023-01-13 16:13:07 FileZilla - Running preflightCommand 2023-01-13 16:13:07 Uninstalling FileZilla - LaunchDaemons 2023-01-13 16:13:07 Uninstalling FileZilla - LaunchAgents 2023-01-13 16:13:07 Checking for blocking processes... 2023-01-13 16:13:07 Found blocking process filezilla 2023-01-13 16:13:07 Stopping process filezilla
2023-01-13 16:13:07 Uninstalling FileZilla - Files and Directories 2023-01-13 16:13:07 Removing directory /Applications/FileZilla.app... 2023-01-13 16:13:07 INFO: /Users/maikelwork/Library/Preferences/org.filezilla-project.filezilla.plist is not an existing file or folder 2023-01-13 16:13:07 Removing directory /Users/maikelwork/Library/Saved Application State/org.filezilla-project.filezilla.savedState... 2023-01-13 16:13:07 Running FileZilla - postflightCommand 2023-01-13 16:13:07 Checking for receipt..
2023-01-13 16:13:07 ERROR: /Library/Application Support/JAMF/bin/Management Action.app/Contents/MacOS/Management Action not installed for showing notifications. Falling back to AppleScript 2023-01-13 16:13:07 Uninstaller Finished