### PR TITLE
Create androidfiletransfer.sh

### DIFF
--- a/fragments/labels/androidfiletransfer.sh
+++ b/fragments/labels/androidfiletransfer.sh
@@ -1,0 +1,7 @@
+androidfiletransfer)
+      appTitle="Android File Transfer"
+      appProcesses+=("Android File Transfer")
+      appProcesses+=("Android File Transfer Agent")
+      appFiles+=("/Applications/Android File Transfer.app")
+      appFiles+=("/Users/$loggedInUser/Library/Preferences/com.google.android.mtpviewer.plist")
+      ;;

--- a/fragments/labels/findanyfile.sh
+++ b/fragments/labels/findanyfile.sh
@@ -1,0 +1,7 @@
+findanyfile)
+      appTitle="Find Any File"
+      appProcesses+=("Find Any File")
+      appFiles+=("/Applications/Find Any File.app")
+      appFiles+=("/Users/$loggedInUser/Library/Application Support/Find Any File/FAF.log")
+      appFiles+=("/Users/$loggedInUser/Library/Preferences/org.tempel.findanyfile.plist")
+;;


### PR DESCRIPTION
Uninstaller started - version 2022-12-27 (build: Tue Apr  4 21:15:30 CEST 2023) Android File Transfer - Running preflightCommand
Uninstalling Android File Transfer - LaunchDaemons Uninstalling Android File Transfer - LaunchAgents
Checking for blocking processes...
Found blocking process Android File Transfer
Stopping process Android File Transfer
Found blocking process Android File Transfer Agent Stopping process Android File Transfer Agent
Uninstalling Android File Transfer - Files and Directories Removing directory /Applications/Android File Transfer.app... Removing file /Users/testuser/Library/Preferences/com.google.android.mtpviewer.pli Running Android File Transfer - postflightCommand
Checking for receipt..
Uninstaller Finished