### PR TITLE
Create displaylinkmanager.sh

### DIFF
--- a/fragments/labels/displaylinkmanager.sh
+++ b/fragments/labels/displaylinkmanager.sh
@@ -1,0 +1,10 @@
+displaylinkmanager)
+      appTitle="DisplayLinkUserAgent"
+      appFiles+=("/Applications/DisplayLink Manager.app")
+      appFiles+=("/Users/$loggedInUser/Library/Application Scripts/com.displaylink.DisplayLinkLoginHelper")
+      appFiles+=("/Users/$loggedInUser/Library/Application Scripts/com.displaylink.DisplayLinkUserAgent")
+      appFiles+=("/Users/$loggedInUser/Library/Containers/com.displaylink.DisplayLinkLoginHelper")
+      appFiles+=("/Users/$loggedInUser/Library/Containers/com.displaylink.DisplayLinkUserAgent")
+      appFiles+=("/Users/$loggedInUser/Library/Group Containers/73YQY62QM3.com.displaylink.DisplayLinkShared")
+      appReceipts+=("com.displaylink.displaylinkmanagerapp")
+      ;;


### PR DESCRIPTION
2023-05-31 15:16:04 Uninstaller started - version 2022-12-27 (build: Tue Apr  4 21:15:30 CEST 2023) 2023-05-31 15:16:04 DisplayLinkUserAgent - Running preflightCommand 2023-05-31 15:16:04 Uninstalling DisplayLinkUserAgent - LaunchDaemons 2023-05-31 15:16:04 Uninstalling DisplayLinkUserAgent - LaunchAgents 2023-05-31 15:16:04 Checking for blocking processes... 2023-05-31 15:16:04 Found blocking process DisplayLinkUserAgent 2023-05-31 15:16:04 Stopping process DisplayLinkUserAgent 2023-05-31 15:16:07 Uninstalling DisplayLinkUserAgent - Files and Directories 2023-05-31 15:16:07 Removing directory /Applications/DisplayLink Manager.app... 2023-05-31 15:16:07 Removing directory /Users/user/Library/Application Scripts/com.displaylink.DisplayLinkLoginHelper... 2023-05-31 15:16:07 Removing directory /Users/user/Library/Application Scripts/com.displaylink.DisplayLinkUserAgent... 2023-05-31 15:16:07 Removing directory /Users/user/Library/Containers/com.displaylink.DisplayLinkLoginHelper... 2023-05-31 15:16:07 Removing directory /Users/user/Library/Containers/com.displaylink.DisplayLinkUserAgent... 2023-05-31 15:16:07 Removing directory /Users/user/Library/Group Containers/73YQY62QM3.com.displaylink.DisplayLinkShared... 2023-05-31 15:16:07 Running DisplayLinkUserAgent - postflightCommand 2023-05-31 15:16:07 Checking for receipt..
2023-05-31 15:16:07 Removing DisplayLinkUserAgent receipts Forgot package 'com.displaylink.displaylinkmanagerapp' on '/'. 2023-05-31 15:16:08 Uninstaller Finished