### PR TITLE
Add argument for ignoring user files

### DIFF
--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -36,3 +36,8 @@ swiftDialog="/usr/local/bin/dialog"
 appVersionKey="CFBundleShortVersionString"
 appBundleIdentifierKey="CFBundleIdentifier"
 
+# ignore deletion of files in user directories
+IGNORE_USER_DIRS=0
+# options:
+# 0            delete files/directories in user directories
+# 1            ignore deletion of files in user directories, with exception of LaunchAgents

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -84,12 +84,16 @@ fi
 for file in "${appFiles[@]}"
 do
 	if [[ "$file" == *"<<Users>>"* ]]; then
-		# remove path with expanded path for all available userfolders
-		for userfolder in $(ls /Users)
-		do
-			expandedPath=$(echo $file | sed "s|<<Users>>|/Users/$userfolder|g")
-			removeFileDirectory "$expandedPath" silent
-		done
+		if [[ $IGNORE_USER_DIRS == 0 ]]; then
+			# remove path with expanded path for all available userfolders
+			for userfolder in $(ls /Users)
+				do
+					expandedPath=$(echo $file | sed "s|<<Users>>|/Users/$userfolder|g")
+					removeFileDirectory "$expandedPath" silent
+			done
+		else
+			printlog "Ignoring deletion of user files: $file" 
+		fi
 	else
 		# remove real path 
 		removeFileDirectory "$file"


### PR DESCRIPTION
There are a some occasions where removing users files aren't appreciated. I.e. when reinstalling an app by uninstalling+installing.
Adding this won't affect already deployed uninstall scripts, since removal of user files is on by default. It will however allow for giving the user to remove only the app or both app and user files if presented in a Self Service environment.