### PR TITLE
Added adobedigitaleditions

### DIFF
--- a/fragments/labels/adobedigitaleditions.sh
+++ b/fragments/labels/adobedigitaleditions.sh
@@ -1,0 +1,9 @@
+adobedigitaleditions)
+# Needs more testing
+      appTitle="Adobe Digital Editions"
+      appProcesses+=("Adobe Digital Editions")
+      appFiles+=("/Applications/Adobe Digital Editions.app")
+      adobedigitaleditionsSymlinkDestination=$(readlink "/Applications/Adobe Digital Editions.app")
+      appFiles+=("${adobedigitaleditionsSymlinkDestination}")
+      appFiles+=("<<Users>>/Library/Preferences/com.adobe.adobedigitaleditions.app.plist")
+      ;;


### PR DESCRIPTION
FYI, 
`adobedigitaleditionsSymlinkDestination=$(readlink "/Applications/Adobe Digital Editions.app")`
is used to delete the actual .app, since it is installed with a trailing version number