### PR TITLE
Corrected AppTitle for DYMO Connect

### DIFF
--- a/fragments/labels/dymoconnect.sh
+++ b/fragments/labels/dymoconnect.sh
@@ -1,5 +1,5 @@
 dymoconnect)
-      appTitle="Citrix Workspace"
+      appTitle="DYMO Connect"
       appFiles+=("/Applications/DYMO Connect.app")
       appFiles+=("<<Users>>/Library/DYMOConnect")
       appFiles+=("/Library/PrivilegedHelperTools/com.dymo.dymo-connect.helper")


### PR DESCRIPTION
The original label still had the appTitle from Citrix Workspace