### PR TITLE
Add user apps path to spotify

### DIFF
--- a/fragments/labels/spotify.sh
+++ b/fragments/labels/spotify.sh
@@ -1,6 +1,7 @@
 spotify)
       appTitle="Spotify"
       appFiles+=("/Applications/Spotify.app")
+      appFiles+=("<<Users>>/Applications/Spotify.app")
       appFiles+=("<<Users>>/Library/Application Support/Spotify/")
       appFiles+=("<<Users>>/Library/HTTPStorages/com.spotify.client")
       appFiles+=("<<Users>>/Library/Preferences/com.spotify.client.plist")

--- a/uninstaller.sh
+++ b/uninstaller.sh
@@ -1407,6 +1407,7 @@ sourcetree)
 spotify)
       appTitle="Spotify"
       appFiles+=("/Applications/Spotify.app")
+      appFiles+=("<<Users>>/Applications/Spotify.app")
       appFiles+=("<<Users>>/Library/Application Support/Spotify/")
       appFiles+=("<<Users>>/Library/HTTPStorages/com.spotify.client")
       appFiles+=("<<Users>>/Library/Preferences/com.spotify.client.plist")

--- a/uninstaller.sh
+++ b/uninstaller.sh
@@ -1407,7 +1407,6 @@ sourcetree)
 spotify)
       appTitle="Spotify"
       appFiles+=("/Applications/Spotify.app")
-      appFiles+=("<<Users>>/Applications/Spotify.app")
       appFiles+=("<<Users>>/Library/Application Support/Spotify/")
       appFiles+=("<<Users>>/Library/HTTPStorages/com.spotify.client")
       appFiles+=("<<Users>>/Library/Preferences/com.spotify.client.plist")


### PR DESCRIPTION
We've realized that users tend to save Spotify in their local Apps directory as well.
this makes it easier to remove both /Applications/Spotify.app and all ~/Applications/Spotify.app