### PR TITLE
Add LiveReplayer

### DIFF
--- a/fragments/labels/livereplayer.sh
+++ b/fragments/labels/livereplayer.sh
@@ -1,0 +1,7 @@
+livereplayer)
+      appTitle="LiveReplayer"
+      appProcesses+=("LiveReplayer")
+      appFiles+=("/Applications/LiveReplayer.app")
+      appFiles+=("<<Users>>/Library/Application Support/com.fsm.mac.LiveReplayer")
+      appFiles+=("<<Users>>/Library/Preferences/com.fsm.mac.LiveReplayer.plist")
+      ;;


### PR DESCRIPTION
Haven't run the app myself, so there might be more user dirs created once you login to the app.

```
sudo utils/assemble.sh livereplayer NOTIFICATIONTYPE=swiftdialog NOTIFY=success IGNORE_USER_DIRS=1 swiftDialogNotification=notification DEBUG=0
Password:
2025-01-23 10:28:33 Uninstaller started - build 2025-01-23
2025-01-23 10:28:33 setting variable from argument NOTIFICATIONTYPE=swiftdialog
2025-01-23 10:28:33 setting variable from argument NOTIFY=success
2025-01-23 10:28:33 setting variable from argument IGNORE_USER_DIRS=1
2025-01-23 10:28:33 setting variable from argument swiftDialogNotification=notification
2025-01-23 10:28:33 setting variable from argument DEBUG=0
2025-01-23 10:28:33 LiveReplayer - Running preflightCommand
2025-01-23 10:28:33 Uninstalling LiveReplayer - LaunchDaemons
2025-01-23 10:28:33 Uninstalling LiveReplayer - LaunchAgents
2025-01-23 10:28:33 Checking for blocking processes...
2025-01-23 10:28:33 Found blocking process LiveReplayer
2025-01-23 10:28:33 Stopping process LiveReplayer
2025-01-23 10:28:36 Uninstalling LiveReplayer - Files and Directories
2025-01-23 10:28:36 Removing directory /Applications/LiveReplayer.app...
2025-01-23 10:28:36 Ignoring deletion of user files: <<Users>>/Library/Application Support/com.fsm.mac.LiveReplayer
2025-01-23 10:28:36 Ignoring deletion of user files: <<Users>>/Library/Preferences/com.fsm.mac.LiveReplayer.plist
2025-01-23 10:28:36 Running LiveReplayer - postflightCommand
2025-01-23 10:28:36 Checking for receipt..
2025-01-23 10:28:37 Uninstaller Finished
```